### PR TITLE
docs: スペルチェックにwordを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,10 @@
     "cSpell.words": [
         "audioplayers",
         "barcodeokapi",
+        "compilesdkversion",
         "czrc",
         "Marp",
+        "pubspec",
         "Qiita",
         "randomuser",
         "riverpod"

--- a/barcodeokapi/lib/ui/pick_image/pick_image_page.dart
+++ b/barcodeokapi/lib/ui/pick_image/pick_image_page.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
+// import 'package:image_picker/image_picker.dart';
 
 /// 画像取り込み画面
 class PickImagePage extends StatefulWidget {
@@ -12,7 +12,7 @@ class PickImagePage extends StatefulWidget {
 
 class _SettingPageState extends State<PickImagePage> {
   File? _image;
-  final picker = ImagePicker();
+  // final picker = ImagePicker();
 
   Future _getImage() async {
     // final pickedFile = await picker.getImage(source: ImageSource.gallery);

--- a/barcodeokapi/pubspec.lock
+++ b/barcodeokapi/pubspec.lock
@@ -169,14 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
-  cross_file:
-    dependency: transitive
-    description:
-      name: cross_file
-      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+4"
   crypto:
     dependency: transitive
     description:
@@ -254,14 +246,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.0"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: c224ac897bed083dabf11f238dd11a239809b446740be0c2044608c50029ffdf
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.9"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -323,14 +307,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
@@ -355,22 +331,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.15"
-  image_picker:
-    dependency: "direct main"
-    description:
-      name: image_picker
-      sha256: "6ef5aa1c92236daa18ae71e81b93b3f238acef3c69d1533ae4dc283f50965c8b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
-  image_picker_platform_interface:
-    dependency: transitive
-    description:
-      name: image_picker_platform_interface
-      sha256: "1991219d9dbc42a99aff77e663af8ca51ced592cd6685c9485e3458302d3d4f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.3"
   io:
     dependency: transitive
     description:
@@ -467,14 +427,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.4"
   pointycastle:
     dependency: transitive
     description:

--- a/barcodeokapi/pubspec.yaml
+++ b/barcodeokapi/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   hooks_riverpod:
   # アルバムやカメラアプリを利用する為
   # TODO: バージョンは要確認
-  # `image_picker ライブラリは、Android SDK のバージョンによっては動作しない可能性があります。しかし、compilesdkversion を 30 のままにして image_picker を使用することはできます。以下はその方法です。
+  # `image_picker ライブラリは、Android SDK のバージョンによっては動作しない可能性があります。しかし、 compilesdkversion を 30 のままにして image_picker を使用することはできます。以下はその方法です。
   #
   # image_picker のバージョンを更新する
   # まず、image_picker のバージョンを最新に更新することをお勧めします。これにより、最新の Android SDK バージョンで動作するようにライブラリが更新されます。以下のように pubspec.yaml ファイルを更新してください。

--- a/barcodeokapi/pubspec.yaml
+++ b/barcodeokapi/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   #
   # image_picker のバージョンを更新する
   # まず、image_picker のバージョンを最新に更新することをお勧めします。これにより、最新の Android SDK バージョンで動作するようにライブラリが更新されます。以下のように pubspec.yaml ファイルを更新してください。
-  image_picker: 0.7.0
+  # image_picker: 0.7.0
 
   # json ←→ Object の from, to を楽にする為
   json_annotation: ^4.8.0


### PR DESCRIPTION
整理:

対応前:
実行すると, 以下エラー
```
Launching lib/main.dart on sdk gphone64 x86 64 in debug mode...
main.dart:1
Warning: The plugin flutter_plugin_android_lifecycle requires Android SDK version 33.
For more information about build configuration, see https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
One or more plugins require a higher Android SDK version.
Fix this issue by adding the following to /Users/apple/myDev/barcodeokapi/barcodeokapi/android/app/build.gradle:
android {
  compileSdkVersion 33
  ...
}


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':image_picker:parseDebugLocalResources'.
> Could not resolve all files for configuration ':image_picker:androidApis'.
   > Failed to transform android.jar to match attributes {artifactType=android-platform-attr, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.
      > Execution failed for PlatformAttrTransform: /Users/apple/Library/Android/sdk/platforms/android-29/android.jar.
         > /Users/apple/Library/Android/sdk/platforms/android-29/android.jar

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
```

対応後:
実行すると, ビルドできるが image_picker 使えない